### PR TITLE
Added source clampping to avoid outliers

### DIFF
--- a/config/structures.py
+++ b/config/structures.py
@@ -47,6 +47,7 @@ class Config:
     peel_off_window_size: int = 200
     peel_off_repeats: bool = True
     remove_bad_fr: bool = True
+    clamp_percentile: Optional[float] = None
 
     # ICA parameters
     max_ica_steps: int = 1000


### PR DESCRIPTION
Clamping to avoid the effect of oulying spikes. If clamp_percentile is specified, the corresponding percentiles are used to clamp each swarm source estimate if outliers are detected (difference btw max and min is larger than 5 times the std). Otherwise the default clamping applies (max val = 30).