### PR TITLE
Improved spike detection

### DIFF
--- a/scd/config/structures.py
+++ b/scd/config/structures.py
@@ -75,6 +75,7 @@ class Config:
     use_coeff_var_fitness: bool = True
 
     # Timestamping parameters
+    square_sources_spike_det: bool = False
     reset_peak_separation: int = 40
     final_peak_separation: int = 40
     source_centroid_weighting: float = 0.0

--- a/scd/models/scd.py
+++ b/scd/models/scd.py
@@ -238,6 +238,10 @@ class SwarmContrastiveDecomposition(torch.nn.Module):
         """Find the timestamps with a two class k means/median clustering.
         and aggregate. Calculates a fitness function for the swarm."""
 
+        # Square sources for spike detection if specified in config
+        if self.config.square_sources_spike_det:
+            sources = sources ** 2
+        
         # Calculate timestamps from k means with associated silhouettes
         timestamps, spike_heights, silhouettes = zip(
             *[


### PR DESCRIPTION
Fixed centroid bootstrapping calculation.
Also added option to square sources for spike detection in config under 'square_sources_spike_det' for better spike/baseline separation. 'square_sources_spike_det' defaults to False for consistency with prior behaviour, but setting it to True improves yield.